### PR TITLE
"fixed" SVG canvas grey bar

### DIFF
--- a/apps/frontend/src/components/SVGCanvas.tsx
+++ b/apps/frontend/src/components/SVGCanvas.tsx
@@ -490,7 +490,7 @@ export default function SVGCanvas(props: {
       height="100vh"
       width="auto"
       preserveAspectRatio="xMidYMid meet"
-      viewBox="0 0 5000 3400"
+      viewBox="0 250 5000 2813"
       overflow="clip"
       onMouseMove={(e) => handleMouseMove(e)}
       onMouseUp={(e) => handleMouseUp(e)}


### PR DESCRIPTION
changed scaling on SVG canvas bar to fit a 16:9 aspect ratio (2560x1440)